### PR TITLE
version 1.0.7

### DIFF
--- a/duplicati/CHANGELOG.md
+++ b/duplicati/CHANGELOG.md
@@ -1,5 +1,10 @@
 <!-- https://developers.home-assistant.io/docs/add-ons/presentation#keeping-a-changelog -->
 
+## 0.1.7
+- ✔️ Update Duplicati to v2.0.6.3-2.0.6.3_beta_2021-06-17
+- 🖥️ Debian Base Image 6.1.1
+    ⬆️ Upgrades Debian to Bullseye 20221205
+
 ## 0.1.6
 
 - ✔️ bump home-assistant/builder from 2022.09.0 to 2022.11.0

--- a/duplicati/Dockerfile
+++ b/duplicati/Dockerfile
@@ -31,11 +31,6 @@ RUN apt-get update \
   && apt-get install -y binutils curl mono-devel ca-certificates-mono fsharp mono-vbnc nuget referenceassemblies-pcl \
   && rm -rf /var/lib/apt/lists/* /tmp/*
 
-# RUN apk add --no-cache mono --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
-    # apk add --no-cache --virtual=.build-dependencies ca-certificates && \
-    #cert-sync /etc/ssl/certs/ca-certificates.crt && \
-    #apk del .build-dependencies
-
 RUN set -xe && \
 	echo "**** install duplicati ****" && \
 	mkdir -p /app/duplicati && \

--- a/duplicati/build.yaml
+++ b/duplicati/build.yaml
@@ -1,10 +1,10 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-dockerfile
 build_from:
-  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:6.1.3
-  amd64: ghcr.io/hassio-addons/debian-base/amd64:6.1.3
-  armhf: ghcr.io/hassio-addons/debian-base/armhf:6.1.3
-  armv7: ghcr.io/hassio-addons/debian-base/armv7:6.1.3
-  i386: ghcr.io/hassio-addons/debian-base/i386:6.1.3
+  aarch64: ghcr.io/hassio-addons/debian-base/aarch64:6.2.0
+  amd64: ghcr.io/hassio-addons/debian-base/amd64:6.2.0
+  armhf: ghcr.io/hassio-addons/debian-base/armhf:6.2.0
+  armv7: ghcr.io/hassio-addons/debian-base/armv7:6.2.0
+  i386: ghcr.io/hassio-addons/debian-base/i386:6.2.0
 labels:
   org.opencontainers.image.title: "Home Assistant Add-on: Duplicati add-on"
   org.opencontainers.image.description: "Duplicati add-on Backup Software."

--- a/duplicati/config.yaml
+++ b/duplicati/config.yaml
@@ -1,6 +1,6 @@
 # https://developers.home-assistant.io/docs/add-ons/configuration#add-on-config
 name: Duplicati add-on
-version: "0.1.6"
+version: "0.1.7"
 slug: duplicati
 description: Store securely encrypted backups on cloud storage services!
 url: "https://github.com/adrianoamalfi/hassos-addons/tree/main/duplicati"


### PR DESCRIPTION
- ✔️ Update Duplicati to v2.0.6.3-2.0.6.3_beta_2021-06-17
- 🖥️ Debian Base Image 6.1.1
    ⬆️ Upgrades Debian to Bullseye 20221205