### PR TITLE
Capability to read all files and directories

### DIFF
--- a/duplicati/apparmor.txt
+++ b/duplicati/apparmor.txt
@@ -6,6 +6,7 @@ profile example flags=(attach_disconnected,mediate_deleted) {
   # Capabilities
   file,
   signal (send) set=(kill,term,int,hup,cont),
+  capability dac_read_search,
 
   # S6-Overlay
   /init ix,

--- a/duplicati/config.yaml
+++ b/duplicati/config.yaml
@@ -17,6 +17,9 @@ startup: services
 init: false
 backup_exclude: ["/backup"]
 
+privileged:
+- DAC_READ_SEARCH
+
 map:
   - config:rw
   - ssl:rw


### PR DESCRIPTION
With current addon configuration its not possible to backup directories with no permissions for other users. With this changes duplicati will be able to backup that directories and files, too.