### PR TITLE
feat: open webui port

### DIFF
--- a/duplicati/config.yaml
+++ b/duplicati/config.yaml
@@ -12,6 +12,10 @@ arch:
   - i386
 ingress: true
 ingress_port: 8200
+ports:
+  8200/tcp: 8200
+ports_description:
+  8200/tcp: "webui"
 panel_icon: mdi:backup-restore
 startup: services
 init: false


### PR DESCRIPTION
Hi Adriano, 

Duplicate has an API REST out of the box, so we can play with it and manually integrate duplicati over home assistant if we can access it by opening the port to access duplicati in another way than ingress. What do you think?